### PR TITLE
Add compiletime attribute (+Add more ChefSpec tests) (rebased)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 3.1'
-gem 'chefspec',   '~> 4.0'
+gem 'chefspec',   '~> 4.1'
 gem 'chef-sugar', '~> 1.1'
 gem 'foodcritic', '~> 3.0'
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Tested on FreeBSD 7.2, 8.0, 8.1, 8.2, 9.2 and 10.0.
 
 Attributes
 ----------
+| Attribute                                 | Default | Description
+|-----------                                |---------|-------------
+| `node['freebsd']['compiletime_portsnap']` | `false` | Execute portsnap resources at compile time
 
 Usage
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: freebsd
+# Attributes:: default
+#
+# Copyright 2014, Onddo Labs, SL.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['freebsd']['compiletime_portsnap'] = false

--- a/recipes/portsnap.rb
+++ b/recipes/portsnap.rb
@@ -28,7 +28,7 @@ else
   # The sed forces portsnap to run non-interactively
   # fetch downloads a ports snapshot, extract puts them on disk (long)
   # update will update an existing ports tree
-  script 'create non-interactive portsnap' do
+  s = script 'create non-interactive portsnap' do
     interpreter 'sh'
     code <<-EOS
       set -e # ensure we exit at first non-zero
@@ -36,12 +36,20 @@ else
       chmod +x #{portsnap_bin}
     EOS
     not_if { File.exist?(portsnap_bin) }
+    action(node['freebsd']['compiletime_portsnap'] ? :nothing : :run)
   end
+  s.run_action(:run) if node['freebsd']['compiletime_portsnap']
 end
 
 # Ensure we have a ports tree
 unless File.exist?('/usr/ports/.portsnap.INDEX')
-  execute "#{portsnap_bin} fetch extract #{portsnap_options}".strip
+  e = execute "#{portsnap_bin} fetch extract #{portsnap_options}".strip do
+    action(node['freebsd']['compiletime_portsnap'] ? :nothing : :run)
+  end
+  e.run_action(:run) if node['freebsd']['compiletime_portsnap']
 end
 
-execute "#{portsnap_bin} update #{portsnap_options}".strip
+e = execute "#{portsnap_bin} update #{portsnap_options}".strip do
+  action(node['freebsd']['compiletime_portsnap'] ? :nothing : :run)
+end
+e.run_action(:run) if node['freebsd']['compiletime_portsnap']

--- a/spec/recipes/portsnap_spec.rb
+++ b/spec/recipes/portsnap_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'freebsd::portsnap' do
-  let(:chef_runner) { ChefSpec::SoloRunner.new }
+  let(:chef_runner) { ChefSpec::ServerRunner.new }
   let(:chef_run) { chef_runner.converge(described_recipe) }
   let(:node) { chef_runner.node }
   before do
@@ -15,7 +15,7 @@ describe 'freebsd::portsnap' do
   end
 
   context 'on FreeBSD 9' do
-    let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2') }
+    let(:chef_runner) { ChefSpec::ServerRunner.new(platform: 'freebsd', version: '9.2') }
     let(:portsnap_bin) { File.join(Chef::Config[:file_cache_path], 'portsnap') }
     let(:portsnap_options) { '' }
 
@@ -55,7 +55,7 @@ describe 'freebsd::portsnap' do
   end # context on FreeBSD 9
 
   context 'on FreeBSD 10' do
-    let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '10.0') }
+    let(:chef_runner) { ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.0') }
     let(:portsnap_bin) { 'portsnap' }
     let(:portsnap_options) { '--interactive' }
 
@@ -97,7 +97,7 @@ describe 'freebsd::portsnap' do
     before { node.set['freebsd']['compiletime_portsnap'] = true }
 
     context 'on FreeBSD 9' do
-      let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2') }
+      let(:chef_runner) { ChefSpec::ServerRunner.new(platform: 'freebsd', version: '9.2') }
       let(:portsnap_bin) { File.join(Chef::Config[:file_cache_path], 'portsnap') }
 
       it 'generates a patched portsnap bin' do
@@ -137,7 +137,7 @@ describe 'freebsd::portsnap' do
     end # context on FreeBSD 9
 
     context 'on FreeBSD 10' do
-      let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '10.0') }
+      let(:chef_runner) { ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.0') }
       let(:portsnap_bin) { 'portsnap' }
       let(:portsnap_options) { '--interactive' }
 

--- a/spec/recipes/portsnap_spec.rb
+++ b/spec/recipes/portsnap_spec.rb
@@ -1,43 +1,175 @@
 require 'spec_helper'
 
 describe 'freebsd::portsnap' do
-  let(:chef_run) { ChefSpec::ServerRunner.converge(described_recipe) }
-
-  let(:portsnap_bin) { 'portsnap' }
-  let(:portsnap_options) { '--interactive' }
-
-  it 'fetches and extracts with the default portsnap' do
-    expect(chef_run).to run_execute("#{portsnap_bin} fetch extract #{portsnap_options}")
+  let(:chef_runner) { ChefSpec::SoloRunner.new }
+  let(:chef_run) { chef_runner.converge(described_recipe) }
+  let(:node) { chef_runner.node }
+  before do
+    orig_file_exist = ::File.method(:exist?)
+    allow(::File).to receive(:exist?) { |*args| orig_file_exist.call(*args) }
   end
 
-  it 'updates the extracted ports tree' do
-    expect(chef_run).to run_execute("#{portsnap_bin} update #{portsnap_options}")
+  it 'Compile Time should be disabled by default' do
+    chef_run
+    expect(node['freebsd']['compiletime_portsnap']).to be(false)
   end
 
-  context 'the ports tree is already extracted' do
-    before do
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX').and_return(true)
-    end
-
-    it 'does not fetch and extract' do
-      expect(chef_run).to_not run_execute("#{portsnap_bin} fetch extract #{portsnap_options}")
-    end
-  end
-
-  context 'FreeBSD 9' do
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'freebsd', version: '9.2')
-        .converge(described_recipe)
-    end
+  context 'on FreeBSD 9' do
+    let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2') }
     let(:portsnap_bin) { File.join(Chef::Config[:file_cache_path], 'portsnap') }
+    let(:portsnap_options) { '' }
 
-    it 'generates a patched portsnap bin' do
-      expect(chef_run).to run_script('create non-interactive portsnap').with(interpreter: 'sh')
+    it 'does not generate a patched portsnap bin' do
+      expect(chef_run).to run_script('create non-interactive portsnap')
+        .at_converge_time
     end
 
-    it 'fetches and extracts with the patched portsnap bin' do
-      expect(chef_run).to run_execute("#{portsnap_bin} fetch extract")
+    it 'updates the extracted ports tree with the default portsnap' do
+      expect(chef_run).to run_execute("#{portsnap_bin} update")
+        .at_converge_time
     end
-  end
+
+    context 'when the ports tree is already extracted' do
+      before do
+        allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+          .and_return(true)
+      end
+
+      it 'does not fetch and extract' do
+        expect(chef_run).to_not run_execute("#{portsnap_bin} fetch extract")
+      end
+    end # context when the ports tree is already extracted
+
+    context 'when the ports tree is not extracted' do
+      before do
+        allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+          .and_return(false)
+      end
+
+      it 'fetches and extracts with the default portsnap' do
+        expect(chef_run).to run_execute("#{portsnap_bin} fetch extract")
+          .at_converge_time
+      end
+    end # context when the ports tree is not extracted
+
+  end # context on FreeBSD 9
+
+  context 'on FreeBSD 10' do
+    let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '10.0') }
+    let(:portsnap_bin) { 'portsnap' }
+    let(:portsnap_options) { '--interactive' }
+
+    it 'does not generate a patched portsnap bin' do
+      expect(chef_run).to_not run_script('create non-interactive portsnap')
+    end
+
+    it 'updates the extracted ports tree with the patched portsnap bin' do
+      expect(chef_run).to run_execute("#{portsnap_bin} update #{portsnap_options}")
+        .at_converge_time
+    end
+
+    context 'when the ports tree is already extracted' do
+      before do
+        allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+          .and_return(true)
+      end
+
+      it 'does not fetch and extract' do
+        expect(chef_run).to_not run_execute("#{portsnap_bin} fetch extract #{portsnap_options}")
+      end
+    end # context when the ports tree is already extracted
+
+    context 'when the ports tree is not extracted' do
+      before do
+        allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+          .and_return(false)
+      end
+
+      it 'fetches and extracts with the patched portsnap bin' do
+        expect(chef_run).to run_execute("#{portsnap_bin} fetch extract #{portsnap_options}")
+          .at_converge_time
+      end
+    end # context when the ports tree is not extracted
+
+  end # context on FreeBSD 10
+
+  context 'with Compile Time' do
+    before { node.set['freebsd']['compiletime_portsnap'] = true }
+
+    context 'on FreeBSD 9' do
+      let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2') }
+      let(:portsnap_bin) { File.join(Chef::Config[:file_cache_path], 'portsnap') }
+
+      it 'generates a patched portsnap bin' do
+        expect(chef_run).to run_script('create non-interactive portsnap')
+          .with_interpreter('sh')
+          .at_compile_time
+      end
+
+      it 'updates the extracted ports tree with the default portsnap' do
+        expect(chef_run).to run_execute("#{portsnap_bin} update")
+          .at_compile_time
+      end
+
+      context 'when the ports tree is already extracted' do
+        before do
+          allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+            .and_return(true)
+        end
+
+        it 'does not fetch and extract' do
+          expect(chef_run).to_not run_execute("#{portsnap_bin} fetch extract")
+        end
+      end # context when the ports tree is already extracted
+
+      context 'when the ports tree is not extracted' do
+        before do
+          allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+            .and_return(false)
+        end
+
+        it 'fetches and extracts with the default portsnap' do
+          expect(chef_run).to run_execute("#{portsnap_bin} fetch extract")
+            .at_compile_time
+        end
+      end # context when the ports tree is not extracted
+
+    end # context on FreeBSD 9
+
+    context 'on FreeBSD 10' do
+      let(:chef_runner) { ChefSpec::SoloRunner.new(platform: 'freebsd', version: '10.0') }
+      let(:portsnap_bin) { 'portsnap' }
+      let(:portsnap_options) { '--interactive' }
+
+      it 'updates the extracted ports tree with the patched portsnap bin' do
+        expect(chef_run).to run_execute("#{portsnap_bin} update #{portsnap_options}")
+          .at_compile_time
+      end
+
+      context 'when the ports tree is already extracted' do
+        before do
+          allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+            .and_return(true)
+        end
+
+        it 'does not fetch and extract' do
+          expect(chef_run).to_not run_execute("#{portsnap_bin} fetch extract #{portsnap_options}")
+        end
+      end # context when the ports tree is already extracted
+
+      context 'when the ports tree is not extracted' do
+        before do
+          allow(::File).to receive(:exist?).with('/usr/ports/.portsnap.INDEX')
+            .and_return(false)
+        end
+
+        it 'fetches and extracts with the patched portsnap bin' do
+          expect(chef_run).to run_execute("#{portsnap_bin} fetch extract #{portsnap_options}")
+            .at_compile_time
+        end
+      end # context when the ports tree is not extracted
+
+    end # context on FreeBSD 10
+
+  end # context with Compile Time
 end

--- a/spec/recipes/portsnap_spec.rb
+++ b/spec/recipes/portsnap_spec.rb
@@ -4,10 +4,7 @@ describe 'freebsd::portsnap' do
   let(:chef_runner) { ChefSpec::ServerRunner.new }
   let(:chef_run) { chef_runner.converge(described_recipe) }
   let(:node) { chef_runner.node }
-  before do
-    orig_file_exist = ::File.method(:exist?)
-    allow(::File).to receive(:exist?) { |*args| orig_file_exist.call(*args) }
-  end
+  before { allow(::File).to receive(:exist?).and_call_original }
 
   it 'Compile Time should be disabled by default' do
     chef_run

--- a/test/integration/pkgng/serverspec/Gemfile
+++ b/test/integration/pkgng/serverspec/Gemfile
@@ -1,0 +1,7 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+source 'https://rubygems.org'
+
+gem 'serverspec', '~> 2.0'

--- a/test/integration/portsnap/serverspec/Gemfile
+++ b/test/integration/portsnap/serverspec/Gemfile
@@ -1,0 +1,7 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+source 'https://rubygems.org'
+
+gem 'serverspec', '~> 2.0'


### PR DESCRIPTION
Issue #13 rebased after #14:

> I added a `node['freebsd']['compiletime_portsnap']` attribute [like in the apt cookbook](https://github.com/opscode-cookbooks/apt#attributes). I've also fixed some issues related with some tests.

All the changes included in this PR:

* Add `compiletime_portsnap` attribute: 2a58a3a
* Add more ChefSpec tests: 589e891
* Update ChefSpec to 4.1: de24aef
* Add Gemfiles for Serverspec: 527f49d

Some notes:

* The ChefSpec tests rebase has been a bit painful. I tried to keep your test descriptions over mine.
* I leave `node['freebsd']['compiletime_pkgng']` out of this PR to avoid more complexity. It will probably be a future PR.